### PR TITLE
firewall: T4430: T2194:  Fix firewall output bugs

### DIFF
--- a/scripts/firewall/vyatta-show-firewall.pl
+++ b/scripts/firewall/vyatta-show-firewall.pl
@@ -329,6 +329,8 @@ sub print_detail_rule {
 
  # trim leading and trailing whitespaces
  $string =~ s/^\s+|\s+$//g;
+ # Hide comments like /* foo-20 */ T2194
+ $string =~ s/\/\* $chain-$rule \*\///;
  @string_words = split (/\s+/, $string, 13);
  @string_words_part1=splice(@string_words, 0, 4); # packets, bytes, target, proto
  
@@ -359,7 +361,7 @@ sub print_detail_rule {
   if ($iptables_cmd =~ /6/) {
    @string_words_part3=splice(@string_words, 5);# all other matches after comment
   } else {
-   @string_words_part3=splice(@string_words, 6);# all other matches after comment
+   @string_words_part3=splice(@string_words, 3);# all other matches after comment
   }
  }
  my $condition='condition - ';

--- a/scripts/firewall/vyatta-show-firewall.pl
+++ b/scripts/firewall/vyatta-show-firewall.pl
@@ -46,7 +46,7 @@ sub convert_to_easyunits {
 }
 
 sub numerically { $a <=> $b; }
-my $format1  = "%-5s %-8s %-9s %-8s %-40s";
+my $format1  = "%-9s %-8s %-9s %-8s %-40s";
 my $format2  = "  %-78s";
 
 # mapping from config node to root config node. 


### PR DESCRIPTION
T4430: 
As we extended firewall rules to 1000000 in 7e00db3
 Output from firewall column "action" should be shifted to the right by a few characters
 Cosmetic fix

Also T2194 iptables have different format of the output of logs, so output script should be changed

https://phabricator.vyos.net/T4430
https://phabricator.vyos.net/T2194

```
vyos@testrouter:~$ show firewall 

-----------------------------
Rulesets Information
-----------------------------
--------------------------------------------------------------------------------
IPv4 Firewall "foo":

 Active on (eth4,IN)

rule      action   proto     packets  bytes                                   
----      ------   -----     -------  -----                                   
10        drop     all       0        0                                       
  condition - saddr 0.0.0.0/0 daddr 192.0.2.5                                   

20        drop     tcp       0        0                                       
  condition - saddr 0.0.0.0/0 daddr 0.0.0.0/0 tcp dpt:345                       

1000000   drop     all       0        0                                       
  condition - saddr 0.0.0.0/0 daddr 0.0.0.0/0                                   

--------------------------------------------------------------------------------
IPv6 Firewall "6INSIDE-OUT":

 Active on (eth1,OUT)

rule      action   proto     packets  bytes                                   
----      ------   -----     -------  -----                                   
9025      reject   tcp_udp   0        0                                       
  condition - saddr ::/0 daddr ::/0 icmp6-port-unreachableLOG enabled           

9026      reject   tcp_udp   0        0                                       
  condition - saddr ::/0 daddr ::/0 icmp6-port-unreachable                      

1000000   accept   all       0        0                                       
  condition - saddr ::/0 daddr ::/0 
```